### PR TITLE
Add video in device content

### DIFF
--- a/dist/devices.css
+++ b/dist/devices.css
@@ -41,10 +41,15 @@
 }
 
 .device-iphone-x .device-content {
-  background-image: url("../src/img/bg-00.jpg");
   border-radius: 32px;
   height: 650px;
   width: 300px;
+}
+video {
+    border-radius: 32px;
+    width: 100% !important;
+    height: 100% !important;
+    object-fit: fill; !important;
 }
 
 .device-iphone-x .device-stripe::after,

--- a/index.html
+++ b/index.html
@@ -31,7 +31,11 @@
         <div class="column col-12">
           <div class="device device-iphone-x">
             <div class="device-frame">
-              <div class="device-content"></div>
+              <div class="device-content">
+                  <video   preload="auto" autoplay loop muted="muted" volume="0">
+                      <source src="src/vid/IphoneX.mp4" type="video/mp4">
+                  </video>
+              </div>
             </div>
             <div class="device-stripe"></div>
             <div class="device-header"></div>


### PR DESCRIPTION
This commit tries to resolve #4 in a nice way. 
I have added the Iphone X promo video (mp4) in the Iphone X device content container without breaking the responsiveness. Similarly videos for other devices can be added too. 