### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "yarn run gulp watch"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ You can add any screenshot or video with the `device-content` class. The resolut
 
 You can custom Devices.css by modifing SASS `.scss` files located in `src` folder.
 
+[![Run on Repl.it](https://repl.it/badge/github/picturepan2/devices.css)](https://repl.it/github/picturepan2/devices.css)
+
 ## Browser support
+
 Devices.css uses [Autoprefixer](https://github.com/postcss/autoprefixer) to make most styles compatible with earlier browsers. For best compatibility, these browsers are recommended:
 
 - Chrome (LAST 4)


### PR DESCRIPTION
This pull request adds a `.replit` file and a badge to the `README`. If you aren't familiar with Repl.it, it's a free cloud IDE that's a really valuable tool for a lot of programmers. This will let anyone quickly start editing Devices.css code without setting up a local dev environment or installing anything.

Feel free to test it out here!  
[![Run on Repl.it](https://repl.it/badge/github/automerge/automerge)](https://repl.it/github/automerge/automerge)